### PR TITLE
🔧 Update survey frame URL and remove unused constant

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,8 +1,7 @@
 export const MAX_BYTE_SIZE = 320
-export const SURVEY_FRAME_URL = 'https://weponder.io/farcaster/surveys'
+export const SURVEY_FRAME_URL = 'https://frame.weponder.io/api/polls'
 export const CREATE_SURVEY_FRAME_URL =
   'https://weponder.io/api/surveys/frames/new'
-export const FRAME_URL = 'https://weponder.io/farcaster/frame'
 
 export const EDGE_FUNCTIONS_SERVER_URL =
   process.env.EDGE_FUNCTIONS_SERVER_URL || 'https://edgefunctions.weponder.io'


### PR DESCRIPTION
- Change `SURVEY_FRAME_URL` to use new API endpoint
- Remove unused `FRAME_URL` constant