### PR TITLE
updated embed link and messaging for Q&A bounties

### DIFF
--- a/src/api/questionsQual.ts
+++ b/src/api/questionsQual.ts
@@ -50,20 +50,38 @@ const updateNextQuestionQual = async (questionId: string) => {
 const getQuestionBountyAmount = async (questionId: string) => {
   const { data, error } = await supabaseClient
     .from('questions_qual_bounties')
-    .select('bounty_amount:questions_qual_bounty_rewards(amount)')
+    .select(
+      'id, token_amount, token_name, questions_qual_bounty_rewards(amount)'
+    )
     .eq('question_id', questionId)
-    .single()
+    .limit(1)
 
   if (error) {
     console.error(`${getDateTag()} ${error}`)
     throw new Error(error.message)
   }
 
-  return data.bounty_amount as BountyAmount
+  if (data && data.length > 0) {
+    const bounty = data[0]
+    let totalRewards = 0
+
+    if (Array.isArray(bounty.questions_qual_bounty_rewards)) {
+      totalRewards = bounty.questions_qual_bounty_rewards.reduce(
+        (sum, reward) => sum + (reward.amount || 0),
+        0
+      )
+    } else if (
+      bounty.questions_qual_bounty_rewards &&
+      'amount' in bounty.questions_qual_bounty_rewards
+    ) {
+      totalRewards = bounty.questions_qual_bounty_rewards.amount || 0
+    }
+
+    const amount = bounty.token_amount - totalRewards
+    return { amount, tokenName: bounty.token_name }
+  }
+
+  return { amount: 0, tokenName: '' }
 }
 
 export { getNextQuestionsQual, updateNextQuestionQual, getQuestionBountyAmount }
-
-interface BountyAmount {
-  amount: number[]
-}

--- a/src/api/questionsQual.ts
+++ b/src/api/questionsQual.ts
@@ -47,4 +47,23 @@ const updateNextQuestionQual = async (questionId: string) => {
   )
 }
 
-export { getNextQuestionsQual, updateNextQuestionQual }
+const getQuestionBountyAmount = async (questionId: string) => {
+  const { data, error } = await supabaseClient
+    .from('questions_qual_bounties')
+    .select('bounty_amount:questions_qual_bounty_rewards(amount)')
+    .eq('question_id', questionId)
+    .single()
+
+  if (error) {
+    console.error(`${getDateTag()} ${error}`)
+    throw new Error(error.message)
+  }
+
+  return data.bounty_amount as BountyAmount
+}
+
+export { getNextQuestionsQual, updateNextQuestionQual, getQuestionBountyAmount }
+
+interface BountyAmount {
+  amount: number[]
+}

--- a/src/services/publishNextQuestionsQualUpdate.ts
+++ b/src/services/publishNextQuestionsQualUpdate.ts
@@ -16,15 +16,12 @@ const publishNextQuestionsQualUpdate = async () => {
     const questionQualHash = questionQual.cast_hash as string
     const responseCount = await getAnswersCount(questionQual.id)
 
-    const bountyAmount = await getQuestionBountyAmount(questionQual.id)
-
-    const numBounties =
-      bountyAmount.amount[0] === 0 ? 0 : bountyAmount.amount[0] / 3
+    const { amount, tokenName } = await getQuestionBountyAmount(questionQual.id)
 
     const updateMessage = formatReplyToQuestionQual(
       responseCount,
-      numBounties,
-      questionQual.id
+      amount,
+      tokenName
     )
 
     if (process.env.NODE_ENV === 'production') {

--- a/src/services/publishNextQuestionsQualUpdate.ts
+++ b/src/services/publishNextQuestionsQualUpdate.ts
@@ -1,11 +1,12 @@
 import {
   getNextQuestionsQual,
+  getQuestionBountyAmount,
   updateNextQuestionQual,
 } from '../api/questionsQual'
 import { publishReply } from '../api/casts'
 import { getDateTag } from '../utils/getDateTag'
 import { getAnswersCount } from '../api/answersQual'
-import { QUESTION_FRAME_URL } from '../utils/constants'
+import { APP_URL } from '../utils/constants'
 import { formatReplyToQuestionQual } from '../utils/formatQuestionQual'
 
 const publishNextQuestionsQualUpdate = async () => {
@@ -14,7 +15,14 @@ const publishNextQuestionsQualUpdate = async () => {
   for await (const questionQual of questionsQual) {
     const questionQualHash = questionQual.cast_hash as string
     const responseCount = await getAnswersCount(questionQual.id)
-    const updateMessage = formatReplyToQuestionQual(responseCount)
+
+    const bountyAmount = await getQuestionBountyAmount(questionQual.id)
+
+    const updateMessage = formatReplyToQuestionQual(
+      responseCount,
+      bountyAmount.amount[0] / 3,
+      questionQual.id
+    )
 
     if (process.env.NODE_ENV === 'production') {
       try {
@@ -23,7 +31,7 @@ const publishNextQuestionsQualUpdate = async () => {
             'question reply',
             questionQualHash,
             updateMessage,
-            `${QUESTION_FRAME_URL}/${questionQual.id}`
+            `${APP_URL}/questions/${questionQual.id}`
           )
 
           await updateNextQuestionQual(questionQual.id)
@@ -42,7 +50,7 @@ const publishNextQuestionsQualUpdate = async () => {
     } else {
       if (questionQualHash && responseCount > 0) {
         console.log(
-          `${getDateTag()} Mock question update:\n${updateMessage}\n${QUESTION_FRAME_URL}/${
+          `${getDateTag()} Mock question update:\n${updateMessage}\n${APP_URL}/questions/${
             questionQual.id
           }`
         )

--- a/src/services/publishNextQuestionsQualUpdate.ts
+++ b/src/services/publishNextQuestionsQualUpdate.ts
@@ -18,9 +18,12 @@ const publishNextQuestionsQualUpdate = async () => {
 
     const bountyAmount = await getQuestionBountyAmount(questionQual.id)
 
+    const numBounties =
+      bountyAmount.amount[0] === 0 ? 0 : bountyAmount.amount[0] / 3
+
     const updateMessage = formatReplyToQuestionQual(
       responseCount,
-      bountyAmount.amount[0] / 3,
+      numBounties,
       questionQual.id
     )
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -10,4 +10,4 @@ export const EDGE_FUNCTIONS_SERVER_URL =
 export const EDGE_FUNCTIONS_SECRET_TOKEN =
   process.env.EDGE_FUNCTIONS_SECRET_TOKEN
 
-export const APP_URL = process.env.APP_URL || 'https://weponder.io'
+export const APP_URL = process.env.APP_URL || 'https://www.weponder.io'

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,3 +9,5 @@ export const EDGE_FUNCTIONS_SERVER_URL =
 
 export const EDGE_FUNCTIONS_SECRET_TOKEN =
   process.env.EDGE_FUNCTIONS_SECRET_TOKEN
+
+export const APP_URL = process.env.APP_URL || 'https://weponder.io'

--- a/src/utils/formatQuestionQual.ts
+++ b/src/utils/formatQuestionQual.ts
@@ -1,8 +1,19 @@
-const formatReplyToQuestionQual = (responseCount: number): string => {
+import { APP_URL } from './constants'
+
+const formatReplyToQuestionQual = (
+  responseCount: number,
+  numBounties: number,
+  questionId: string
+): string => {
   const updateInterval = Number(
     process.env.NEXT_QUESTION_QUAL_UPDATE_INTERVAL_HOURS || 24
   ) // Default to 24 hours if not set
-  return `💭 Your question got ${responseCount} responses after ${updateInterval} hours. Read them all here:`
+
+  const msg = `💭 Your question got ${responseCount} responses and you still have ${numBounties} bounties to award after ${updateInterval} hours.
+
+Reward responses directly in the frame. You can also read all of them here: ${APP_URL}/questions/${questionId}`
+
+  return msg
 }
 
 export { formatReplyToQuestionQual }

--- a/src/utils/formatQuestionQual.ts
+++ b/src/utils/formatQuestionQual.ts
@@ -1,17 +1,19 @@
-import { APP_URL } from './constants'
-
 const formatReplyToQuestionQual = (
   responseCount: number,
   numBounties: number,
-  questionId: string
+  tokenName: string
 ): string => {
   const updateInterval = Number(
     process.env.NEXT_QUESTION_QUAL_UPDATE_INTERVAL_HOURS || 24
   ) // Default to 24 hours if not set
 
-  const msg = `💭 Your question got ${responseCount} responses and you still have ${numBounties} bounties to award after ${updateInterval} hours.
+  const msg = `💭 Your question got ${responseCount} responses${
+    numBounties
+      ? ` and you still have ${numBounties} ${tokenName} in bounties to award`
+      : ''
+  } after ${updateInterval} hours.
 
-Reward responses directly in the frame. You can also read all of them here: ${APP_URL}/questions/${questionId}`
+Reward responses directly in the frame. You can also read all of them here:`
 
   return msg
 }


### PR DESCRIPTION
I haven't tested yet, had trouble generating snaplet data. But I have a question regarding the number of bounties in the messaging. For now I'm dividing the amount by 3 as that's what we were using during the OP campaign. Is this always going to be the case? If not, how are we meant to get this data? A solution is to message the actual amount remaining; we'll have to update the code to pull the token details from `questions_qual_bounties`.

Relevant code is below:
https://github.com/ponder-surveys/farcaster-survey-bot/blob/8f9d3042402714107a748e07100e03f6564b002c/src/services/publishNextQuestionsQualUpdate.ts#L19-L28